### PR TITLE
fix(#34): 자주하는 질문/답변 긴 문자열도 저장되게 수정 (#40)

### DIFF
--- a/src/main/java/kusitms/hdmedi/domain/qna/Qna.java
+++ b/src/main/java/kusitms/hdmedi/domain/qna/Qna.java
@@ -1,9 +1,6 @@
 package kusitms.hdmedi.domain.qna;
 
-import jakarta.persistence.Entity;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.GenerationType;
-import jakarta.persistence.Id;
+import jakarta.persistence.*;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -23,6 +20,8 @@ public class Qna {
 
     private String question;
 
+    @Lob
+    @Column(columnDefinition = "TEXT")
     private String answer;
 
     @CreationTimestamp

--- a/src/main/java/kusitms/hdmedi/dto/response/qna/QnaResponse.java
+++ b/src/main/java/kusitms/hdmedi/dto/response/qna/QnaResponse.java
@@ -22,6 +22,6 @@ public class QnaResponse {
         id = qna.getId();
         question = qna.getQuestion();
         answer = qna.getAnswer();
-        createdAt = qna.getCreatedAt().format(DateTimeFormatter.ofPattern("yyyy.mm.dd"));
+        createdAt = qna.getCreatedAt().format(DateTimeFormatter.ofPattern("yyyy.MM.dd"));
     }
 }

--- a/src/main/java/kusitms/hdmedi/service/qna/QnaService.java
+++ b/src/main/java/kusitms/hdmedi/service/qna/QnaService.java
@@ -46,6 +46,7 @@ public class QnaService {
         return qnaResponses;
     }
 
+    @Transactional
     public void create(QnaRequest qnaRequest) {
         Qna qna = Qna.builder()
                 .question(qnaRequest.getQuestion())


### PR DESCRIPTION
## 개요

자주하는 질문/답변 answer 컬럼이 varchar(255) 였는데, 긴 문자열 등록하려니 잘려서 등록이 됨

## 작업사항

- 자주하는 질문/답변 answer 타입 varchar(255) -> text

## 변경로직

- 자주하는 질문/답변 긴 문자열도 저장되게 수정
